### PR TITLE
Fixes an issue where all member edit panels disappear if you don't ha…

### DIFF
--- a/includes/opt-in-lists-functions.php
+++ b/includes/opt-in-lists-functions.php
@@ -240,7 +240,7 @@ function pmpro_mailpoet_member_edit_panels( $panels ) {
 	// If no opt-in lists are set, bail. We don't need to show the panel.
 	$options = pmpro_mailpoet_get_options();
 	if ( empty( $options['opt-in_lists'] ) ) {
-		return;
+		return $panels;
 	}
 
 	// If the class doesn't exist and the abstract class does, require the class.


### PR DESCRIPTION
…ve an opt-in list setup

### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/MailPoet-Paid-Memberships-Pro-Add-on/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/MailPoet-Paid-Memberships-Pro-Add-on/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Returns the existing panels if there are no opt-in lists

### How to test the changes in this Pull Request:

1. Navigate to Memberships > Members and edit a member
2. All panels should still show even if there aren't any opt-in lists available


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

