### PR TITLE
Remove MailPoet admin bar menu item

### DIFF
--- a/includes/settings.php
+++ b/includes/settings.php
@@ -16,30 +16,6 @@ function pmpro_mailpoet_add_admin_page() {
 add_action( 'admin_menu', 'pmpro_mailpoet_add_admin_page', 20 );
 
 /**
- * Add MailPoet settings menu to admin bar.
- *
- * @since 3.0
- */
-function pmpro_mailpoet_admin_bar_menu() {
-	global $wp_admin_bar;
-	if ( ! is_super_admin() || ! is_admin_bar_showing() ) {
-		return;
-	}
-	$wp_admin_bar->add_menu(
-		array(
-			'id'     => 'pmpro-mailpoet',
-			'parent' => 'paid-memberships-pro',
-			'title'  => esc_html__( 'MailPoet', 'mailpoet-paid-memberships-pro-add-on' ),
-			'href'   => get_admin_url(
-				null,
-				'/admin.php?page=pmpro-mailpoet'
-			),
-		)
-	);
-}
-add_action( 'admin_bar_menu', 'pmpro_mailpoet_admin_bar_menu', 1000 );
-
-/**
  * Render the MailPoet settings page.
  *
  * @since 3.0
@@ -180,14 +156,14 @@ function pmpro_mailpoet_admin_warnings() {
 /**
  * Add description for General Settings section.
  *
- * @since 3.2
+ * @since TBD
  */
 function pmpro_mailpoet_section_general_lists() {
 	?>
 	<div id="pmpro-mailpoet-general-lists" class="pmpro_section_toggle" data-visibility="hidden" data-activated="false">
 		<button class="pmpro_section-toggle-button" type="button" aria-expanded="false">
 			<span class="dashicons dashicons-arrow-up-alt2"></span>
-			<?php esc_html_e( 'General Settings', 'mailpoet-paid-memberships-pro-add-on' ); ?>
+			<?php esc_html_e( 'General Settings', 'pmpro-mailpoet' ); ?>
 		</button>
 	</div>
 	<div class="pmpro_section_inside">
@@ -204,7 +180,7 @@ function pmpro_mailpoet_section_membership_lists() {
 	<div id="pmpro-mailpoet-membership-lists" class="pmpro_section_toggle" data-visibility="hidden" data-activated="false">
 		<button class="pmpro_section-toggle-button" type="button" aria-expanded="false">
 			<span class="dashicons dashicons-arrow-up-alt2"></span>
-			<?php esc_html_e( 'Membership Lists', 'mailpoet-paid-memberships-pro-add-on' ); ?>
+			<?php esc_html_e( 'Membership Lists', 'pmpro-mailpoet' ); ?>
 		</button>
 	</div>
 	<div class="pmpro_section_inside">

--- a/includes/settings.php
+++ b/includes/settings.php
@@ -156,14 +156,14 @@ function pmpro_mailpoet_admin_warnings() {
 /**
  * Add description for General Settings section.
  *
- * @since TBD
+ * @since 3.2
  */
 function pmpro_mailpoet_section_general_lists() {
 	?>
 	<div id="pmpro-mailpoet-general-lists" class="pmpro_section_toggle" data-visibility="hidden" data-activated="false">
 		<button class="pmpro_section-toggle-button" type="button" aria-expanded="false">
 			<span class="dashicons dashicons-arrow-up-alt2"></span>
-			<?php esc_html_e( 'General Settings', 'pmpro-mailpoet' ); ?>
+			<?php esc_html_e( 'General Settings', 'mailpoet-paid-memberships-pro-add-on' ); ?>
 		</button>
 	</div>
 	<div class="pmpro_section_inside">
@@ -180,7 +180,7 @@ function pmpro_mailpoet_section_membership_lists() {
 	<div id="pmpro-mailpoet-membership-lists" class="pmpro_section_toggle" data-visibility="hidden" data-activated="false">
 		<button class="pmpro_section-toggle-button" type="button" aria-expanded="false">
 			<span class="dashicons dashicons-arrow-up-alt2"></span>
-			<?php esc_html_e( 'Membership Lists', 'pmpro-mailpoet' ); ?>
+			<?php esc_html_e( 'Membership Lists', 'mailpoet-paid-memberships-pro-add-on' ); ?>
 		</button>
 	</div>
 	<div class="pmpro_section_inside">


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/MailPoet-Paid-Memberships-Pro-Add-on/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/MailPoet-Paid-Memberships-Pro-Add-on/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Resolves #12 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Removes MailPoet from admin bar menu items
