### PR TITLE
Hide notice on the PMPro MailPoet settings page if MailPoet is installed

### DIFF
--- a/mailpoet-paid-memberships-pro-add-on.php
+++ b/mailpoet-paid-memberships-pro-add-on.php
@@ -26,7 +26,7 @@ function pmpro_mailpoet_show_notice() {
 	global $msg, $msgt;
 
 	// MailPoet V3 is installed, just bail.
-	if ( function_exists( 'mailpoet_deactivate_plugin' ) ) {
+	if ( class_exists( 'MailPoet\Config\Env' ) ) {
 		return;
 	}
 	// Show the notice here.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/MailPoet-Paid-Memberships-Pro-Add-on/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/MailPoet-Paid-Memberships-Pro-Add-on/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
The `mailpoet_deactivate_plugin` function is not present in recent versions of Mailpoet. A notice displays on the Mailpoet settings page prompting users to activate MailPoet even when it's active.
![image](https://github.com/user-attachments/assets/cf4fe116-d9fc-4dea-9b98-3adaeab22e1d)

Resolves issue by checking if Mailpoet class exists instead.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->